### PR TITLE
Add pt-br translation

### DIFF
--- a/Rofl.Settings/Models/GeneralSettings.cs
+++ b/Rofl.Settings/Models/GeneralSettings.cs
@@ -45,7 +45,7 @@ namespace Rofl.Settings.Models
 
     public enum Language
     {
-        En, ZhHans, De, Es
+        En, ZhHans, De, Es, Pt
     }
 
     public class GeneralSettings

--- a/Rofl.UI.Main/Resources/Strings/pt.xaml
+++ b/Rofl.UI.Main/Resources/Strings/pt.xaml
@@ -1,0 +1,416 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:string="clr-namespace:System;assembly=mscorlib"
+                    xmlns:system="clr-namespace:System;assembly=System">
+
+    <!--  General UI Text  -->
+    <string:String x:Key="ProgramName">ReplayBook</string:String>
+    <string:String x:Key="SearchDefaultText">Procurar...</string:String>
+    <string:String x:Key="MoreButtonText">Opções</string:String>
+    <string:String x:Key="LoadMoreButtonText">Carregar mais...</string:String>
+
+    <string:String x:Key="LoadingMessageReplay">Carregando os replays...</string:String>
+    <string:String x:Key="LoadingMessageExecutables">Verificando os arquivos executáveis...</string:String>
+    <string:String x:Key="LoadingMessageThumbnails">Carregando as thumbnails...</string:String>
+    <string:String x:Key="LoadingMessageErrors">Não foi possível carregar um ou mais replays</string:String>
+    <string:String x:Key="LoadingFailureTitle">Falha de Carregamento de Replay</string:String>
+    <string:String x:Key="LoadingFailureSubtitle">Conserte ou remova o(s) arquivo(s) a seguir:</string:String>
+
+    <string:String x:Key="CloseText">Fechar</string:String>
+    <string:String x:Key="YesText">Sim</string:String>
+    <string:String x:Key="NoText">Não</string:String>
+
+    <string:String x:Key="CopyText">Copiar</string:String>
+
+    <string:String x:Key="CheckText">✔</string:String>
+    <string:String x:Key="CrossText">❌</string:String>
+    <string:String x:Key="BlueTeamText">Azul</string:String>
+    <string:String x:Key="RedTeamText">Vermelho</string:String>
+    <string:String x:Key="ScoreboardTabText">PLACAR</string:String>
+    <string:String x:Key="RunesTabText">RUNAS</string:String>
+    <string:String x:Key="StatsTabText">ESTATÍSTICAS</string:String>
+    <string:String x:Key="BlankDetailMessageText">Selecione um replay à esquerda para começar</string:String>
+    <string:String x:Key="FailedToLoadReplayText">Falha ao carregar o replay</string:String>
+    <string:String x:Key="Victory">VITÓRIA</string:String>
+    <string:String x:Key="BlueVictory">Vitória Azul</string:String>
+    <string:String x:Key="RedVictory">Vitória Vermelha</string:String>
+    <string:String x:Key="ErrorTitle">Erro</string:String>
+    <string:String x:Key="ConfirmTitle">Confirmação</string:String>
+    <string:String x:Key="ConfirmText">Você tem certeza?</string:String>
+
+    <string:String x:Key="ReplaySupported">Pode ser assistido</string:String>
+    <string:String x:Key="ReplayUnsupported">Não pode ser assistido</string:String>
+    <string:String x:Key="ReplayPlayExceptionTitle">Uma Exceção Ocorreu</string:String>
+
+    <string:String x:Key="NoReplaysFoundTitle">Sem resultados</string:String>
+
+    <string:String x:Key="MissingPathTitle">Pasta de replays não encontrada</string:String>
+    <string:String x:Key="MissingPathText">Os seguintes caminhos não puderam ser encontrados e portanto foram removidos:</string:String>
+
+    <!--  Settings Window Text  -->
+    <string:String x:Key="GeneralSettingsItemText">Geral</string:String>
+    <string:String x:Key="UpdatesSettingsItemText">Atualizações</string:String>
+    <string:String x:Key="AppearanceSettingsItemText">Aparência</string:String>
+    <string:String x:Key="ReplaySettingsItemText">Replays</string:String>
+    <string:String x:Key="RequestSettingsItemText">Cache</string:String>
+    <string:String x:Key="ExecutablesSettingsItemText">Executáveis</string:String>
+    <string:String x:Key="AboutSettingsItemText">Sobre</string:String>
+
+    <!--  Settings : General  -->
+    <string:String x:Key="LanguageLabelText">Idioma</string:String>
+
+    <string:String x:Key="PlayerMarkerLabelText">Marcadores de Jogador</string:String>
+    <string:String x:Key="PlayerMarkerStyleLabel">Estilo dos Marcadores de Jogador</string:String>
+    <string:String x:Key="PlayerMarkerStyleOption1">Borda ao redor</string:String>
+    <string:String x:Key="PlayerMarkerStyleOption2">Quadradinho no canto</string:String>
+    <string:String x:Key="PlayerMarkerWindowText">Marcador de Jogador</string:String>
+    <string:String x:Key="PlayerMarkerNameLabelText">Nome do Jogador</string:String>
+    <string:String x:Key="PlayerMarkerNoteLabelText">Anotação</string:String>
+    <string:String x:Key="PlayerMarkerColorLabelText">Cor do Marcador</string:String>
+    <string:String x:Key="PlayerMarkerAlreadyExistsErrorText">Marcador para o nome de jogador &quot;$&quot; já existe</string:String>
+    <string:String x:Key="PlayerMarkerNameIsEmptyErrorText">Nome de jogador não pode ser deixado vazio</string:String>
+
+    <string:String x:Key="FileAssociationLabelText">Comportamento de Abrir Arquivo no Windows Explorer</string:String>
+    <string:String x:Key="FileAssociationButtonText">Associar esse programa à abertura de arquivos .ROFL</string:String>
+    <string:String x:Key="FileAssociationMessageTitleText">Associação .ROFL</string:String>
+    <string:String x:Key="FileAssociationMessageBodyText">ReplayBook foi definido como o programa padrão para arquivos .ROFL</string:String>
+    <string:String x:Key="FileActionOption1">Assistir ao replay</string:String>
+    <string:String x:Key="FileActionOption2">Mostrar estatísticas</string:String>
+
+    <string:String x:Key="MiscBehaviorLabelText">Comportamentos diversos</string:String>
+    <string:String x:Key="PlayConfirmCheckboxText">Pedir confirmação antes de assistir a replays</string:String>
+    <string:String x:Key="ReplayRenameCheckboxText">Renomear o arquivo original quando renomear replays</string:String>
+
+    <string:String x:Key="UpdatesLabelText">Procurar Atualizações</string:String>
+    <string:String x:Key="AutoUpdateCheckboxText">Procurar atualizações automaticamente</string:String>
+    <string:String x:Key="CheckUpdatesButtonText">Procurar agora</string:String>
+    <string:String x:Key="UpdateAvailableText">Uma atualização está disponível! Baixe a nova versão aqui</string:String>
+    <string:String x:Key="UpdateAvailableNotifText">Nova versão disponível!</string:String>
+    <string:String x:Key="UpdateAvailableNotifButton">Baixar</string:String>
+    <system:Uri x:Key="GitHubReleasesLink">https://github.com/fraxiinus/ReplayBook/releases/latest</system:Uri>
+    <string:String x:Key="OpenGitHubButtonText">Ver projeto no GitHub</string:String>
+    <string:String x:Key="UpdateExceptionTitleText">Não foi possível procurar por atualizações</string:String>
+    <string:String x:Key="UpdateHTTPExceptionBodyText">Falha ao conectar-se ao GitHub. Cheque sua conexão à internet e tente novamente.</string:String>
+    <string:String x:Key="UpdateGitHubErrorBodyText">GitHub respondeu com erro. Procure por atualizações manualmente em https://github.com/fraxiinus/ReplayBook</string:String>
+    <string:String x:Key="UpdateMostRecentTitleText">Já atualizado</string:String>
+    <string:String x:Key="UpdateMostRecentBodyText">Você está usando a versão mais recente de ReplayBook.</string:String>
+    <string:String x:Key="UpdateNewerTitleText">Nova versão disponível</string:String>
+    <string:String x:Key="UpdateNewerBodyText">Uma versão mais recente de ReplayBook está disponível. Clique em OK para abrir a página de download.</string:String>
+
+    <!--  Settings : Appearance  -->
+    <string:String x:Key="AppearanceThemeModeTitle">Tema</string:String>
+    <string:String x:Key="AppearanceThemeMode0">Seguir o tema do sistema</string:String>
+    <string:String x:Key="AppearanceThemeMode1">Escuro</string:String>
+    <string:String x:Key="AppearanceThemeMode2">Claro</string:String>
+    <string:String x:Key="AppearanceThemeAccentTitle">Cor de destaque</string:String>
+    <string:String x:Key="AppearanceThemeResetColorText">Reset</string:String>
+    <string:String x:Key="AppearanceThemeDefaultAccentNote">Usando mesma cor de destaque que o Windows</string:String>
+    <string:String x:Key="AppearanceThemeCustomAccentNote">Usando cor de destaque personalizada</string:String>
+
+    <string:String x:Key="ExecutableFoldersLabelText">Pastas para procurar por Arquivos Executáveis do LoL</string:String>
+    <string:String x:Key="ExecutableFoldersInfoText">Quaisquer subpastas são inclusas</string:String>
+    <string:String x:Key="ExecutableFoldersSearchButtonText">Escanear Pastas à procura dos Executáveis</string:String>
+    <string:String x:Key="ExecutableFoldersSearchResultTitleText">Resultados de pesquisa</string:String>
+    <string:String x:Key="ExecutableFoldersSearchResultLabelText">$ novos executáveis registrados</string:String>
+    <string:String x:Key="ExecutableFoldersSearchResultErrorText">Não foi possível procurar nas seguintes pastas:</string:String>
+    <string:String x:Key="ExecutablesLabelText">Executáveis do LoL registrados</string:String>
+    <string:String x:Key="ExecutableSelectFolderDialogText">Selecione a pasta de procurar por Arquivos Executáveis do LoL</string:String>
+    <string:String x:Key="ExecutableDetailWindowText">Executáveis</string:String>
+    <string:String x:Key="ExecutableSelectDialogText">Selecione League of Legends.exe</string:String>
+    <string:String x:Key="ExecutableSelectInvalidErrorText">Selecione um executável válido</string:String>
+    <string:String x:Key="ExecutableSelectInvalidErrorTitle">Executável Inválido</string:String>
+    <string:String x:Key="ExecutableSaveNullText">Campos obrigatórios não foram preenchidos</string:String>
+    <string:String x:Key="ExecutableSaveNullTitle">Erro ao salvar</string:String>
+    <string:String x:Key="ExecutableSelectWindowTitleText">Selecione o Executável</string:String>
+    <string:String x:Key="ExecutableNotFoundErrorTitle">Executável não encontrado</string:String>
+    <string:String x:Key="ExecutableNotFoundErrorText">Não foi possível encontrar um executável para esse patch</string:String>
+    <string:String x:Key="ReplayPlayConfirmTitle">Assistir ao replay?</string:String>
+    <string:String x:Key="ReplayPlayConfirmOptOut">Você pode desativar essa confirmação na janela de configurações</string:String>
+
+    <!--  Executable Detail  -->
+    <string:String x:Key="ExecutableDetailTargetPath">Caminho Alvo</string:String>
+    <string:String x:Key="ExecutableDetailName">Nome do Executável</string:String>
+    <string:String x:Key="ExecutableDetailCustomLocale">Locale personalizada</string:String>
+    <string:String x:Key="ExecutableDetailLocale">Locale</string:String>
+    <string:String x:Key="ExecutableDetailLocaleInfo">Replays podem resultador em bugsplat se esse valor não bater com o executável</string:String>
+    <string:String x:Key="ExecutableDetailLaunchArgs">Outros Argumentos de Inicialização</string:String>
+    <string:String x:Key="ExecutableDetailPropertyStartPath">Caminho Inicial</string:String>
+    <string:String x:Key="ExecutableDetailPropertyPatch">Patch</string:String>
+    <string:String x:Key="ExecutableDetailPropertyModified">Data de Modificação</string:String>
+
+    <string:String x:Key="SourceFoldersLabelText">Pastas para procurar por Replays</string:String>
+    <string:String x:Key="SourceFoldersInfoText">Quaisquer subpastas são inclusas</string:String>
+    <string:String x:Key="SourceFoldersWindowText">Selecione a pasta para procurar por Replays </string:String>
+    <string:String x:Key="SourceFoldersAlreadyExistsErrorText">A pasta selecionada já foi adicionada. Por favor escolha outra pasta</string:String>
+    <string:String x:Key="SourceFoldersAlreadyExistsErrorTitle">Pasta já adicionada</string:String>
+
+    <string:String x:Key="ReplayItemsPerPage">Itens por Página</string:String>
+
+    <string:String x:Key="ReplayDatabaseText">Cache de Dados de Replay</string:String>
+    <string:String x:Key="ReplayDatabaseSize">Tamanho:</string:String>
+    <string:String x:Key="ReplayDatabaseClearButton">Limpar esse cache</string:String>
+
+    <string:String x:Key="RequestsDownloadAllLabel">Baixar Imagens</string:String>
+    <string:String x:Key="RequestsCacheLabel">Cache de Imagens Baixadas</string:String>
+    <string:String x:Key="RequestsCacheItemsSize">Tamanho do cache de itens:</string:String>
+    <string:String x:Key="RequestsCacheChampsSize">Tamanho do de campeões:</string:String>
+    <string:String x:Key="RequestsCacheRunesSize">Tamanho do de runas:</string:String>
+    <string:String x:Key="RequestsCacheClearItemsButton">Excluir de itens</string:String>
+    <string:String x:Key="RequestsCacheClearChampsButton">Excluir de Campeões</string:String>
+    <string:String x:Key="RequestsCacheClearRunesButton">Excluir de Runas</string:String>
+    <string:String x:Key="RequestsCacheCloseToDeleteTitle">Fechar ReplayBook</string:String>
+    <string:String x:Key="RequestsCacheCloseToDelete">O Cache será deletado quando o ReplayBok for fechado</string:String>
+    <string:String x:Key="RequestsAdvancedLabel">Opções Avançadas</string:String>
+    <string:String x:Key="DataDragonBaseUrlLabelText">URL Base do Data Dragon</string:String>
+    <string:String x:Key="DataDragonChampionUrlLabelText">URL Relativa de Imagens de Campeão</string:String>
+    <string:String x:Key="DataDragonItemUrlLabelText">URL Relativa de Imagens de Item</string:String>
+    <string:String x:Key="DataDragonMapUrlLabelText">URL Relativa de Mapa</string:String>
+
+    <string:String x:Key="Name">ReplayBook</string:String>
+    <string:String x:Key="Author">Fraxiinus (Etirps)</string:String>
+    <string:String x:Key="GitHubLink">https://github.com/fraxiinus/ReplayBook</string:String>
+    <string:String x:Key="DiscordInviteButton">Entrar no Discord (servidor em inglês)</string:String>
+    <system:Uri x:Key="DiscordInviteLink">https://discord.gg/c33Rc5J</system:Uri>
+    <string:String x:Key="EggEggEgg">buff nidalee 😺</string:String>
+    <string:String x:Key="LicenseText">Esse programa é licensiado sob GPL-3.0</string:String>
+    <system:Uri x:Key="LicenseLink">https://github.com/fraxiinus/ReplayBook/blob/master/LICENSE</system:Uri>
+    <string:String x:Key="AcknowledgementText">o ReplayBook só é possível graças aos seguintes:</string:String>
+    <string:String x:Key="AcknowledgementButtonText">Projetos Open Source</string:String>
+    <string:String x:Key="AcknowledgementWindowTitleText">Créditos Open Source</string:String>
+
+    <!--  Generic button text  -->
+    <string:String x:Key="OKButtonText">OK</string:String>
+    <string:String x:Key="AddButtonText">Adicionar</string:String>
+    <string:String x:Key="EditButtonText">Editar</string:String>
+    <string:String x:Key="RemoveButtonText">Remover</string:String>
+    <string:String x:Key="SaveButtonText">Salvar</string:String>
+    <string:String x:Key="CancelButtonText">Cancelar</string:String>
+    <string:String x:Key="BrowseButtonText">Explorar...</string:String>
+    <string:String x:Key="SelectButtonText">Selecionar</string:String>
+
+    <!--  Stats Header Text  -->
+    <string:String x:Key="CombatGroupHeaderText">Combate</string:String>
+    <string:String x:Key="ChampionsKilledHeaderText">Abates</string:String>
+    <string:String x:Key="DeathsHeaderText">Mortes</string:String>
+    <string:String x:Key="AssistsHeaderText">Assistências</string:String>
+    <string:String x:Key="LargestKillingSpreeHeaderText">Maior Sequência de Abates</string:String>
+    <string:String x:Key="KillingSpreesHeaderText">Qnt. de Sequências de Abate</string:String>
+    <string:String x:Key="LargestMultiKillHeaderText">Maior Multiabates</string:String>
+    <string:String x:Key="BountyLevelHeaderText">Nível de recompensa</string:String>
+    <string:String x:Key="DoubleKillsHeaderText">Double Kills</string:String>
+    <string:String x:Key="TripleKillsHeaderText">Triple Kills</string:String>
+    <string:String x:Key="QuadraKillsHeaderText">Quadra Kills</string:String>
+    <string:String x:Key="PentaKillsHeaderText">Penta Kills</string:String>
+    <string:String x:Key="UnrealKillsHeaderText">Unreal Kills</string:String>
+    <string:String x:Key="CrowdControlScoreHeaderText">Placar de Controle de Grupo</string:String>
+    <string:String x:Key="TotalTimeCrowdControlDealtHeaderText">Tempo de Controle de Grupo</string:String>
+
+    <string:String x:Key="DamageDealtGroupHeaderText">Dano Causado</string:String>
+    <string:String x:Key="TotalDamageDealtToChampionsHeaderText">Dano Total a Campeões</string:String>
+    <string:String x:Key="PhysicalDamageDealtToChampionsHeaderText">Dano Físico a Campeões</string:String>
+    <string:String x:Key="MagicDamageDealtToChampionsHeaderText">Dano Mágico a Campeões</string:String>
+    <string:String x:Key="TrueDamageDealtToChampionsHeaderText">Dano Verdadeiro a Campeões</string:String>
+    <string:String x:Key="TotalDamageDealtHeaderText">Dano Total Causado</string:String>
+    <string:String x:Key="PhysicalDamageDealtHeaderText">Dano Físico Causado</string:String>
+    <string:String x:Key="MagicDamageDealtHeaderText">Dano Mágico Causado</string:String>
+    <string:String x:Key="TrueDamageDealtHeaderText">Dano Verdadeiro Causado</string:String>
+    <string:String x:Key="LargestCriticalStrikeHeaderText">Maior Acerto Crítico</string:String>
+    <string:String x:Key="TotalDamageToTurretsHeaderText">Dano Total às torres</string:String>
+    <string:String x:Key="TotalDamageToObjectivesHeaderText">Dano total aos objetivos</string:String>
+
+    <string:String x:Key="DamageTakenAndHealedGroupHeaderText">Dano Recebido e Curado</string:String>
+    <string:String x:Key="TotalHealingDoneHeaderText">Cura realizada total</string:String>
+    <string:String x:Key="TotalHealingDoneToTeammatesHeaderText">Total de cura aplicada em aliados</string:String>
+    <string:String x:Key="TotalUnitsHealedHeaderText">Total de Unidades Curadas</string:String>
+    <string:String x:Key="TotalDamageShieldedToTeammatesHeaderText">Total de Dano Defendido por Escudo para Aliados</string:String>
+    <string:String x:Key="TotalDamageTakenHeaderText">Dano Recebido Total</string:String>
+    <string:String x:Key="PhysicalDamageTakenHeaderText">Dano Físico Recebido</string:String>
+    <string:String x:Key="MagicDamageTakenHeaderText">Dano Mágico Recebido</string:String>
+    <string:String x:Key="TrueDamageTakenHeaderText">Dano Verdadeiro Recebido</string:String>
+    <string:String x:Key="TotalDamageSelfMitigatedHeaderText">Dano Automitigado Total</string:String>
+
+    <string:String x:Key="VisionGroupHeaderText">Visão</string:String>
+    <string:String x:Key="VisionScoreHeaderText">Placar de Visão</string:String>
+    <string:String x:Key="WardsPlacedHeaderText">Sentinelas Posicionadas</string:String>
+    <string:String x:Key="WardsKilledHeaderText">Sentinelas Destruídas</string:String>
+    <string:String x:Key="VisionWardsPurchasedHeaderText">Sentinelas de Controle Compradas</string:String>
+
+    <string:String x:Key="IncomeGroupHeaderText">Receita</string:String>
+    <string:String x:Key="GoldEarnedHeaderText">Ouro Recebido</string:String>
+    <string:String x:Key="GoldSpentHeaderText">Ouro Gasto</string:String>
+    <string:String x:Key="ItemsPurchasedHeaderText">Itens Comprados</string:String>
+    <string:String x:Key="ConsumablesPurchasedHeaderText">Consumíveis Comprados</string:String>
+    <string:String x:Key="MinionsKilledHeaderText">Tropas Abatidas</string:String>
+    <string:String x:Key="NeutralMinionsKilledHeaderText">Monstros Neutros Abatidos</string:String>
+    <string:String x:Key="NeutralMinionsKilledFromOwnJungleHeaderText">Monstros Neutros Abatidos na Selva Aliada</string:String>
+    <string:String x:Key="NeutralMinionsKilledFromEnemyJungleHeaderText">Monstros Neutros Abatidos na Selva Inimiga</string:String>
+
+    <string:String x:Key="ObjectivesGroupHeaderText">Objetivos</string:String>
+    <string:String x:Key="TotalExperienceHeaderText">Experiência Total</string:String>
+    <string:String x:Key="TurretsKilledHeaderText">Torres Destruídas</string:String>
+    <string:String x:Key="InhibitorsKilledHeaderText">Inibidores Destruídos</string:String>
+    <string:String x:Key="ObjectivesStolenHeaderText">Objetivos Roubados</string:String>
+    <string:String x:Key="BaronsKilledHeaderText">Barões Derrotados</string:String>
+    <string:String x:Key="DragonsKilledHeaderText">Dragões Derrotados</string:String>
+    <string:String x:Key="LongestTimeSpentAliveHeaderText">Maior Duração de Tempo Vivo</string:String>
+    <string:String x:Key="TotalTimeSpentDeadHeaderText">Tempo Passado Morto Total</string:String>
+    <string:String x:Key="LastHitNexusHeaderText">Foi o Último a Bater no Nexus</string:String>
+
+    <string:String x:Key="ToxicityGroupHeaderText">Toxicidade</string:String>
+    <string:String x:Key="TimeSpentDisconnectedHeaderText">Tempo que Passou Desconectado</string:String>
+    <string:String x:Key="TimeOfLastDisconnectHeaderText">Quando foi a Última Desconexão (em segundos)</string:String>
+    <string:String x:Key="PlayersMutedHeaderText">Quantos Jogadores Mutou</string:String>
+    <string:String x:Key="MutedByPlayersHeaderText">Mutado por Quantos Jogadores</string:String>
+    <string:String x:Key="PingHeaderText">Qnt. de Pings</string:String>
+    <string:String x:Key="TeamEarlySurrenderedHeaderText">Equipe fez Rendição Antecipada</string:String>
+    <string:String x:Key="WasAFKHeaderText">Esteve AFK</string:String>
+    <string:String x:Key="WasAFKAfterFailedSurrenderHeaderText">Esteve AFK Após Voto de Rendição Falhar</string:String>
+    <string:String x:Key="WasEarlySurrenderAccompliceHeaderText">Votou Sim na Rendição Antecipada</string:String>
+
+    <string:String x:Key="MiscGroupHeaderText">Diversos</string:String>
+    <string:String x:Key="Spell1CastsHeaderText">Qnt. de Q usados (Skill 1)</string:String>
+    <string:String x:Key="Spell2CastsHeaderText">Qnt. de W usados (Skill 2)</string:String>
+    <string:String x:Key="Spell3CastsHeaderText">Qnt. de E usados (Skill 3)</string:String>
+    <string:String x:Key="Spell4CastsHeaderText">Qnt. de R usados (Skill 4)</string:String>
+    <string:String x:Key="SummonerSpell1CastsHeaderText">Qnt. de D usados (Feitiço de Invocador 1)</string:String>
+    <string:String x:Key="SummonerSpell2CastsHeaderText">Qnt. de F usados (Feitiço de Invocador 1)</string:String>
+    <string:String x:Key="IndividualPositionHeaderText">Posição</string:String>
+
+    <!--  ToolTip Text  -->
+    <string:String x:Key="SortToolTip">Ordenar</string:String>
+    <string:String x:Key="RefreshToolTip">Atualizar</string:String>
+    <string:String x:Key="SettingsToolTip">Configurações</string:String>
+    <string:String x:Key="PlayReplayToolTip">Assistir ao Replay</string:String>
+    <string:String x:Key="AlreadyPlayingToolTip">Já Está em Reprodução...</string:String>
+    <string:String x:Key="CannotPlayToolTip">Não é possível reproduzir esse replay</string:String>
+    <string:String x:Key="MoreToolTip">Mais...</string:String>
+
+    <string:String x:Key="FileDateToolTip">Data de criação do arquivo</string:String>
+    <string:String x:Key="MatchIdToolTip">ID da partida</string:String>
+    <string:String x:Key="FileSizeToolTip">Tamanho do arquivo</string:String>
+    <string:String x:Key="MapNameToolTip">Mapa (melhor chute)</string:String>
+    <string:String x:Key="GameVersionToolTip">Versão do jogo</string:String>
+
+    <string:String x:Key="LevelToolTip">Level</string:String>
+    <string:String x:Key="KillsToolTip">Abates</string:String>
+    <string:String x:Key="DeathsToolTip">Mortes</string:String>
+    <string:String x:Key="AssistsToolTip">Assistências</string:String>
+    <string:String x:Key="CreepScoreToolTip">Tropas abatidas</string:String>
+    <string:String x:Key="GoldEarnedToolTip">Ouro recebido</string:String>
+
+    <!--  sort menu text  -->
+    <string:String x:Key="NameAsc">Nome de A-Z</string:String>
+    <string:String x:Key="NameDesc">Name de Z-A</string:String>
+
+    <string:String x:Key="DateAsc">Data de criação do mais velho ao mais recente</string:String>
+    <string:String x:Key="DateDesc">Data de criação do mais recente ao mais velho</string:String>
+
+    <string:String x:Key="SizeAsc">Tamanho do menor para o maior</string:String>
+    <string:String x:Key="SizeDesc">Tamanho do maior para o menor</string:String>
+
+    <!--  Replay Menu Item Text  -->
+    <string:String x:Key="OpenNewWindow">Abrir em Nova Janela</string:String>
+    <string:String x:Key="OpenContainingFolder">Abrir Local do Arquivo</string:String>
+    <string:String x:Key="ExportReplayData">Exportar Dados...</string:String>
+    <string:String x:Key="RenameReplayFile">Renomear</string:String>
+    <string:String x:Key="DeleteReplayFile">Deletar</string:String>
+    <string:String x:Key="RefreshReplayList">Atualizar Lista</string:String>
+
+    <!--  Export Data : Wizard  -->
+    <string:String x:Key="ErdTitle">Ferramenta de Exportação de Dados</string:String>
+    <string:String x:Key="ErdTitleAdvanced">Modo Avançado de Exportação de Dados</string:String>
+    <string:String x:Key="ErdLandingSubtitle">Escolha das seguintes opções</string:String>
+    <string:String x:Key="ErdLandingStart">Iniciar ferramenta</string:String>
+    <string:String x:Key="ErdLandingPreset">Exportar usando predefinição</string:String>
+    <string:String x:Key="ErdLandingAdvanced">Mostrar modo avançado</string:String>
+    <string:String x:Key="ErdLandingEverything">Exportar tudo</string:String>
+    <string:String x:Key="ErdPlayersSubtitle">Selecione os jogadores a incluir</string:String>
+    <string:String x:Key="ErdPlayersManual">Seleção manual</string:String>
+    <string:String x:Key="ErdPlayersMarkers">Só os que têm marcador</string:String>
+    <string:String x:Key="ErdPlayersAll">Todos jogadores</string:String>
+    <string:String x:Key="ErdAttributesSubtitle">Escolha atributos de jogador</string:String>
+    <string:String x:Key="ErdAttributesFilter">Filtrar atributos...</string:String>
+    <string:String x:Key="ErdFinishFormatHeading">Formato de saída</string:String>
+    <string:String x:Key="ErdFinishFormatCsv">Exportar como CSV</string:String>
+    <string:String x:Key="ErdFinishFormatNormalize">Normalizar nomes dos atributos</string:String>
+    <string:String x:Key="ErdFinishJsonHeading">Opções para JSON</string:String>
+    <string:String x:Key="ErdFinishJsonMatchId">Incluir ID da partida</string:String>
+    <string:String x:Key="ErdFinishJsonDuration">Incluir duração da partida</string:String>
+    <string:String x:Key="ErdFinishJsonVersion">Incluir versão do patch</string:String>
+    <string:String x:Key="ErdPreviewTitle">Prévia dos Dados</string:String>
+
+    <!--  Export Data : Common Items + Presets  -->
+    <string:String x:Key="ErdSelectAllItems">Selecionar Tudo</string:String>
+    <string:String x:Key="ErdDeselectAllItems">Deselecionar Tudo</string:String>
+    <string:String x:Key="ErdExportButtonText">Exportar...</string:String>
+    <string:String x:Key="ErdExportDialogTitle">Escolha o Local de Exportação</string:String>
+    <string:String x:Key="ErdFailedToSave">Falha ao salvar o arquivo</string:String>
+    <string:String x:Key="ErdPresetSave">Salvar como predefinição</string:String>
+    <string:String x:Key="ErdPresetLoad">Carregar uma predefinição</string:String>
+    <string:String x:Key="ErdPresetLoadbutton">Carregar</string:String>
+    <string:String x:Key="ErdPresetLoadTitle">Carregar predefinição</string:String>
+    <string:String x:Key="ErdPresetSaveTitle">Salvar predefinição</string:String>
+    <string:String x:Key="ErdPresetName">Nome</string:String>
+    <string:String x:Key="ErdPresetProperties">Propriedades</string:String>
+    <string:String x:Key="ErdPresetPlayers">Jogadores Selecionados</string:String>
+    <string:String x:Key="ErdPresetAttributes">Atributos Selecionados</string:String>
+    <string:String x:Key="ErdPresetOverwrite">Sobrescrever</string:String>
+    <string:String x:Key="ErdPresetExists">Uma predefinição com este nome já existe. Deseja sobrescreve-la?</string:String>
+    <string:String x:Key="ErdPresetExistsNotify">Nome já existe</string:String>
+    <string:String x:Key="ErdPresetFailed">Falha ao carregar predefinição</string:String>
+    <string:String x:Key="ErdPresetSavedTitle">Predefinição Salva</string:String>
+
+    <!--  Welcome Setup  -->
+    <string:String x:Key="WswWindowTitleText">Configuração Inicial do ReplayBook</string:String>
+    <string:String x:Key="WswPreviousText">Voltar</string:String>
+    <string:String x:Key="WswPreviousDisabled">Não é possível retornar à página anterior</string:String>
+    <string:String x:Key="WswNextText">Avançar</string:String>
+    <string:String x:Key="WswNextDisabled">Não é possível avançar à próxima página</string:String>
+    <string:String x:Key="WswSkipText">Pular</string:String>
+    <string:String x:Key="WswSkipDisabled">Não é possível pular isso</string:String>
+    <string:String x:Key="WswDownloadMissingError">Não foi possível encontrar nada para se baixar - Cheque sua conexão à internet ou pule este passo</string:String>
+    <string:String x:Key="WswDownloadNoSelectionError">Por favor escolha o que baixar</string:String>
+
+    <!--  Welcome Setup : Introduction  -->
+    <string:String x:Key="WswIntroFrameTitle">Boas vindas ao ReplayBook</string:String>
+    <string:String x:Key="WswReplaysFrameTitle">Configuração dos Replays</string:String>
+    <string:String x:Key="WswExecutablesFrameTitle">Configuração dos Executáveis do LoL</string:String>
+    <string:String x:Key="WswRegionFrameTitle">Configuração de Idioma</string:String>
+    <string:String x:Key="WswDownloadFrameTitle">Baixar Recursos para cache</string:String>
+    <string:String x:Key="WswFinishedFrameTitle">Finalizado!</string:String>
+
+    <string:String x:Key="WswIntroductionTitle">Agradecemos por baixar ReplayBook!</string:String>
+    <string:String x:Key="WswIntroductionBody">Primeiro, vamos fazer umas configurações inciais. Clique no botão Avançar abaixo</string:String>
+
+    <string:String x:Key="WswRegionTitle">Defina seu idioma padrão de League of Legends</string:String>
+    <string:String x:Key="WswRegionBody">Escolha um idioma da lista suspensa. O ReplayBook irá registrar seus executáveis com essa língua. Você pode manualmente mudar o idioma de qualquer executável depois se desejar.</string:String>
+    <string:String x:Key="WswExecutablesTitle">Selecione a pasta Riot Games</string:String>
+    <string:String x:Key="WswExecutablesBody">O ReplayBook precisa encontrar e registrar seu(s) League of Legends antes que possa reproduzir replays. Procuraremos nessa pasta todas as versões de League of Legends que nela existirem</string:String>
+    <string:String x:Key="WswExecutablesHint">Exemplo: 'C:\Riot Games'</string:String>
+    <string:String x:Key="WswExecutablesRegisterList">Versões encontradas:</string:String>
+    <string:String x:Key="WswExecutablesRegisterListEmpty">Nada foi encontrado...</string:String>
+
+    <string:String x:Key="WswReplaysTitle">Selecione a pasta de replays</string:String>
+    <string:String x:Key="WswReplaysBody">O ReplayBook não poderá te mostrar nenhum replay se não souber onde eles estão. Verifique que é aqui que eles estão salvos. Você pode adicionar mais pastas depois.</string:String>
+    <string:String x:Key="WswReplaysHint">Por padrão, os replays são salvos em &quot;Documentos\League of Legends\Replays&quot;</string:String>
+
+    <string:String x:Key="WswDownloadTitle">Baixar ícones agora?</string:String>
+    <string:String x:Key="WswDownloadBody">Baixar os ícones pode levar alguns minutos, mas fará o ReplayBook rodar mais rápido. O ReplayBook irá baixar os ícones sob demanda caso pule este passo</string:String>
+    <string:String x:Key="WswDownloadChampionsText">Baixar thumbnails de campões</string:String>
+    <string:String x:Key="WswDownloadItemsText">Baixar thumbnails de itens</string:String>
+    <string:String x:Key="WswDownloadRunesText">Baixar thumbnails de runas</string:String>
+    <string:String x:Key="WswDownloadButton">Baixar</string:String>
+    <string:String x:Key="WswDownloadFinished">Download completo</string:String>
+
+    <string:String x:Key="WswFinishTitle">Configuração finalizada!</string:String>
+    <string:String x:Key="WswFinishBody">Clique &quot;Terminar&quot; e o ReplayBook irá imediatamente abrir com as configurações que você acabou de escolher.</string:String>
+    <string:String x:Key="WswFinishButton">Terminar</string:String>
+
+    <!--  Rename dialog  -->
+    <string:String x:Key="RenameFlyoutEmptyError">Use um nome de arquivo válido</string:String>
+    <string:String x:Key="RenameFlyoutNotFoundError">O replay não está numa das pastas de replay</string:String>
+
+    <!--  Delete dialog  -->
+    <string:String x:Key="DeleteFlyoutLabel">Você tem certeza?</string:String>
+
+</ResourceDictionary>

--- a/Rofl.UI.Main/Rofl.UI.Main.csproj
+++ b/Rofl.UI.Main/Rofl.UI.Main.csproj
@@ -318,6 +318,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="Resources\Strings\pt.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Resources\Styles.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/Rofl.UI.Main/Utilities/LanguageHelper.cs
+++ b/Rofl.UI.Main/Utilities/LanguageHelper.cs
@@ -29,7 +29,8 @@ namespace Rofl.UI.Main.Utilities
                 case Language.Es:
                     dict.Source = new Uri("..\\Resources\\Strings\\es.xaml", UriKind.Relative);
                     break;
-                default:
+                case Language.Pt:
+                    dict.Source = new Uri("..\\Resources\\Strings\\pt.xaml", UriKind.Relative);
                     break;
             }
 
@@ -75,7 +76,8 @@ namespace Rofl.UI.Main.Utilities
                     case Language.Es:
                         languages.Add("Español");
                         break;
-                    default:
+                    case Language.Pt:
+                        languages.Add("Português (Brasil)");
                         break;
                 }
             }
@@ -99,6 +101,8 @@ namespace Rofl.UI.Main.Utilities
                     return "de_DE";
                 case Language.Es:
                     return "es_ES";
+                case Language.Pt:
+                    return "pt_BR";
                 default:
                     return "en_US";
             }

--- a/scripts/generate-runes.py
+++ b/scripts/generate-runes.py
@@ -6,7 +6,7 @@ import json
 
 # add additional languages here:
 # see https://ddragon.leagueoflegends.com/cdn/languages.json for valid languages
-languages = ["en_US", "de_DE", "zh_CN", "es_ES"]
+languages = ["en_US", "de_DE", "zh_CN", "es_ES", "pt_BR"]
 
 # stats runes are not included in Riot's rune list, code them here
 # these are found in the CDragon rune list, search for 'statmods'


### PR DESCRIPTION
I tested with a local build using VS community 2022 and everything seemed fine

`Rofl.UI.Main/Rofl.UI.Main.csproj` was edited manually, I hope there's no problem with that.

I took the liberty of modifying `RequestSettingsItemText´  from Downloads to Cache because it makes more sense to me, as that Settings section has only Thumbnail cache. If you dislike it, I can change it back to Downloads.

I copied most of the Stats translations (damage taken, damage to turrets, etc.) from League itself for users to be more familiar with it.

I removed the "Team" part from RedTeamText and BlueTeamText because otherwise it wouldn't fit, by the way