### PR TITLE
Bug/ash fix exporter misc

### DIFF
--- a/src/Rofl.UI.Main/App.xaml
+++ b/src/Rofl.UI.Main/App.xaml
@@ -38,7 +38,7 @@
             </ResourceDictionary.MergedDictionaries>
 
             <!--  Load icon images  -->
-            <BitmapImage x:Key="ProgramIcon" UriSource="Resources/program_icon.ico"/>
+            <BitmapImage x:Key="ProgramIcon" UriSource="Resources/program_icon.ico" />
 
         </ResourceDictionary>
     </Application.Resources>

--- a/src/Rofl.UI.Main/Pages/ExportWizardAdvanced.xaml
+++ b/src/Rofl.UI.Main/Pages/ExportWizardAdvanced.xaml
@@ -143,7 +143,7 @@
                 </Grid>
             </Grid>
 
-            <Border Grid.Column="1" Background="{DynamicResource TabBackgroundHack}">
+            <Border Grid.Column="1" Background="{DynamicResource TabBackground}">
                 <Grid Margin="12,12,12,12">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -234,7 +234,7 @@
             </Border>
 
             <Border Grid.Column="2"
-                    Background="{DynamicResource TabBackgroundHack}"
+                    Background="{DynamicResource TabBackground}"
                     BorderBrush="{DynamicResource BaseBackground}"
                     BorderThickness="1,0,0,0">
                 <Grid Margin="12">
@@ -311,7 +311,7 @@
             </Border>
 
             <Border Grid.Column="3"
-                    Background="{DynamicResource TabBackgroundHack}"
+                    Background="{DynamicResource TabBackground}"
                     BorderBrush="{DynamicResource BaseBackground}"
                     BorderThickness="1,0,0,0">
                 <Grid Margin="12">

--- a/src/Rofl.UI.Main/Pages/ExportWizardLanding.xaml.cs
+++ b/src/Rofl.UI.Main/Pages/ExportWizardLanding.xaml.cs
@@ -32,7 +32,8 @@ namespace Rofl.UI.Main.Pages
         private void AdvancedButton_Click(object sender, RoutedEventArgs e)
         {
             Window window = Window.GetWindow(this);
-            window.Width = 800;
+            window.Width = 1150;
+            window.Height = 670;
             window.MinWidth = 850;
 
             Context.HideHeader = true;


### PR DESCRIPTION
- Fixed #152, incorrect use of the "TabBackgroundHack" resource caused incorrect background color used in light mode
- advanced exporter starts at larger size instead of being started in smallest size